### PR TITLE
Remove optional on seed and make required in IImage response

### DIFF
--- a/Runware/types.ts
+++ b/Runware/types.ts
@@ -44,7 +44,7 @@ export interface IImage {
   imageDataURI?: string;
   NSFWContent?: boolean;
   cost?: number;
-  seed?: number;
+  seed: number;
 }
 
 export interface ITextToImage extends IImage {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runware/sdk-js",
-  "version": "1.1.21",
+  "version": "1.1.22",
   "description": "The SDK is used to run image inference with the Runware API, powered by the RunWare inference platform. It can be used to generate imaged with text-to-image and image-to-image. It also allows the use of an existing gallery of models or selecting any model or LoRA from the CivitAI gallery. The API also supports upscaling, background removal, inpainting and outpainting, and a series of other ControlNet models.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -644,6 +644,12 @@ export type TImageMaskingResponse = {
 
 ## Changelog
 
+### - v1.1.22
+
+**Added or Changed**
+
+- Fix seed type in IImage
+
 ### - v1.1.21
 
 **Added or Changed**


### PR DESCRIPTION
I checked with the Flaviu, apparently seed is always returned now so can we make it required on the type here? 

It'll mean I can remove some `@ts-ignores` on my side. 