### PR TITLE
TAddModelCheckPoint  - make defaultScheduler a string and required, type also required

### DIFF
--- a/Runware/types.ts
+++ b/Runware/types.ts
@@ -382,8 +382,8 @@ export type TAddModelCheckPoint = {
   defaultCFGScale?: number;
   defaultStrength: number;
   defaultSteps?: number;
-  defaultScheduler?: number;
-  type?: EModelType;
+  defaultScheduler: string;
+  type: EModelType;
 } & TAddModelBaseType;
 
 export type TAddModelLora = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runware/sdk-js",
-  "version": "1.1.26",
+  "version": "1.1.27",
   "description": "The SDK is used to run image inference with the Runware API, powered by the RunWare inference platform. It can be used to generate imaged with text-to-image and image-to-image. It also allows the use of an existing gallery of models or selecting any model or LoRA from the CivitAI gallery. The API also supports upscaling, background removal, inpainting and outpainting, and a series of other ControlNet models.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -644,6 +644,12 @@ export type TImageMaskingResponse = {
 
 ## Changelog
 
+### - v1.1.27
+
+**Added or Changed**
+
+- Fix Checkpoint Model Upload Types
+
 ### - v1.1.26
 
 **Added or Changed**


### PR DESCRIPTION
Fixes https://github.com/Runware/sdk-js/issues/18