### PR TITLE
Fix retry logic

### DIFF
--- a/Runware/async-retry.ts
+++ b/Runware/async-retry.ts
@@ -22,7 +22,7 @@ export const asyncRetry = async (
       maxRetries--;
       if (maxRetries > 0) {
         await delay(delayInSeconds); // Delay before the next retry
-        await asyncRetry(apiCall, { ...options, maxRetries });
+        // Continue loop for next retry attempt
       } else {
         throw error; // Throw the error if max retries are reached
       }

--- a/tests/Runware/async-retry.test.ts
+++ b/tests/Runware/async-retry.test.ts
@@ -1,0 +1,39 @@
+import { expect, test, describe, vi } from "vitest";
+import { asyncRetry } from "../../Runware/async-retry";
+
+describe("asyncRetry - bug tests (these fail due to loop+recursion bug)", () => {
+  test("should properly return result from recursive call", async () => {
+    let callCount = 0;
+    const apiCall = vi.fn(async () => {
+      callCount++;
+      if (callCount < 3) {
+        throw new Error("Failed");
+      }
+      return "success";
+    });
+
+    // This should succeed on the 3rd attempt
+    const result = await asyncRetry(apiCall, { maxRetries: 3 });
+
+    expect(result).toBe("success");
+    expect(apiCall).toHaveBeenCalledTimes(3);
+  });
+
+  test("should not continue loop after successful recursive call", async () => {
+    let callCount = 0;
+    const apiCall = vi.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        throw new Error("First attempt fails");
+      }
+      return `success on attempt ${callCount}`;
+    });
+
+    // With maxRetries=2, should succeed on 2nd attempt
+    const result = await asyncRetry(apiCall, { maxRetries: 2 });
+
+    expect(result).toBe("success on attempt 2");
+    expect(apiCall).toHaveBeenCalledTimes(2);
+  });
+});
+


### PR DESCRIPTION
Fixes a bug in `asyncRetry` where it used both a `while` loop and recursion, causing extra retry attempts.

The recursive call on line 25 in `Runware/async-retry.ts` didn't return its result, so the `while` loop continued executing even after a successful recursive call, leading to more API calls than `maxRetries` specified.