### PR TITLE
Support `async` ControlNet Preprocess Delivery

### DIFF
--- a/Runware/Runware-base.ts
+++ b/Runware/Runware-base.ts
@@ -872,111 +872,38 @@ export class RunwareBase {
     return this.requestImages(params, moreOptions);
   }
 
-  controlNetPreProcess = async ({
-    inputImage,
-    preProcessorType,
-    height,
-    width,
-    outputType,
-    outputFormat,
-    highThresholdCanny,
-    lowThresholdCanny,
-    includeHandsAndFaceOpenPose,
-    includeCost,
-    outputQuality,
-    customTaskUUID,
-    taskUUID: _taskUUID,
-    retry,
-    includeGenerationTime,
-    includePayload,
-  }: IControlNetPreprocess): Promise<IControlNetImage | null> => {
-    const totalRetry = retry || this._globalMaxRetries;
-    let lis: any = undefined;
-
-    const startTime = Date.now();
-
+  controlNetPreProcess = async (
+    payload: IControlNetPreprocess,
+  ): Promise<IControlNetImage | null> => {
+    const { inputImage, skipResponse, deliveryMethod = "async", ...rest } = payload;
     try {
-      return await asyncRetry(
-        async () => {
-          await this.ensureConnection();
-          const image = await this.uploadImage(inputImage);
-          if (!image?.imageUUID) return null;
+      const image = await this.uploadImage(inputImage);
+      if (!image?.imageUUID) return null;
 
-          const taskUUID = _taskUUID || customTaskUUID || getUUID();
-          const payload = {
-            inputImage: image.imageUUID,
-            taskType: ETaskType.IMAGE_CONTROL_NET_PRE_PROCESS,
-            taskUUID,
-            preProcessorType,
-            ...evaluateNonTrue({ key: "height", value: height }),
-            ...evaluateNonTrue({ key: "width", value: width }),
-            ...evaluateNonTrue({ key: "outputType", value: outputType }),
-            ...evaluateNonTrue({ key: "outputFormat", value: outputFormat }),
-            ...evaluateNonTrue({ key: "includeCost", value: includeCost }),
-            ...evaluateNonTrue({
-              key: "highThresholdCanny",
-              value: highThresholdCanny,
-            }),
-            ...evaluateNonTrue({
-              key: "lowThresholdCanny",
-              value: lowThresholdCanny,
-            }),
-            ...evaluateNonTrue({
-              key: "includeHandsAndFaceOpenPose",
-              value: includeHandsAndFaceOpenPose,
-            }),
-            ...(outputQuality ? { outputQuality } : {}),
-          };
-
-          await this.send({
-            ...payload,
-          });
-          lis = this.globalListener({
-            taskUUID,
-          });
-
-          const guideImage = (await getIntervalWithPromise(
-            ({ resolve, reject }) => {
-              const uploadedImage = this.getSingleMessage({
-                taskUUID,
-              });
-
-              if (!uploadedImage) return;
-
-              if (uploadedImage?.error) {
-                reject(uploadedImage);
-                return true;
-              }
-
-              if (uploadedImage) {
-                // delete this._globalMessages[taskUUID];
-                resolve(uploadedImage);
-                return true;
-              }
-            },
-            {
-              debugKey: "unprocessed-image",
-              timeoutDuration: this._timeoutDuration,
-            },
-          )) as IControlNetImage;
-
-          lis.destroy();
-
-          this.insertAdditionalResponse({
-            response: guideImage,
-            payload: includePayload ? payload : undefined,
-            startTime: includeGenerationTime ? startTime : undefined,
-          });
-
-          return guideImage;
+      const request = await this.baseSingleRequest<IControlNetImage>({
+        payload: {
+          ...rest,
+          inputImage: image.imageUUID,
+          taskType: ETaskType.IMAGE_CONTROL_NET_PRE_PROCESS,
+          deliveryMethod,
         },
-        {
-          maxRetries: totalRetry,
-          callback: () => {
-            lis?.destroy();
-          },
-        },
-      );
+        debugKey: "unprocessed-image",
+      });
+
+      if (skipResponse) {
+        return request;
+      }
+
+      if (deliveryMethod === "async") {
+        const taskUUID = request?.taskUUID;
+        const results = await this.pollForAsyncResults<IControlNetImage & { status: string }>({
+          taskUUID,
+          dedupeKey: (response) => response.guideImageUUID,
+        });
+        return results[0] ?? null;
+      }
+
+      return request;
     } catch (e: any) {
       throw e;
     }

--- a/Runware/types.ts
+++ b/Runware/types.ts
@@ -151,6 +151,8 @@ export type IControlNetPreprocess = {
   customTaskUUID?: string;
   taskUUID?: string;
   retry?: number;
+  deliveryMethod?: string;
+  skipResponse?: boolean;
 } & IAdditionalResponsePayload;
 
 // export type IControlNetA = RequireOnlyOne<

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runware/sdk-js",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "The SDK is used to run image inference with the Runware API, powered by the RunWare inference platform. It can be used to generate imaged with text-to-image and image-to-image. It also allows the use of an existing gallery of models or selecting any model or LoRA from the CivitAI gallery. The API also supports upscaling, background removal, inpainting and outpainting, and a series of other ControlNet models.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -742,6 +742,10 @@ export type TImageMaskingResponse = {
 
 ## Changelog
 
+### - v1.3.2
+
+- Support `async` ControlNet Preprocess delivery
+
 ### - v1.3.1
 
 - Add WebSocket health checks: half-open ("zombie") connections are now detected via heartbeat ping/pong and the socket is reconnected before sending, so requests are no longer lost into a dead connection.


### PR DESCRIPTION
## Changes Made

- Added `async` ControlNet preprocess delivery with polling for completed guide image results.
- Refactored ControlNet preprocessing through baseSingleRequest, preserving direct responses for non-async delivery.
- Exposed deliveryMethod and skipResponse options for ControlNet preprocess requests.

### Extra

- Bumped the SDK version to `1.3.2` and documented it.
