### PR TITLE
Fix zombie connection and dry run

### DIFF
--- a/Runware/Runware-base.ts
+++ b/Runware/Runware-base.ts
@@ -95,6 +95,7 @@ export class RunwareBase {
   _heartbeatInterval: number;
   _missedPongCount: number = 0;
   _maxMissedPongs: number = 3;
+  _dryRun: boolean;
   ensureConnectionUUID: string | null = null;
   _logger: RunwareLogger;
 
@@ -106,9 +107,11 @@ export class RunwareBase {
     timeoutDuration = TIMEOUT_DURATION,
     heartbeatInterval = 45000,
     enableLogging = false,
+    dryRun = false,
   }: RunwareBaseType) {
     this._apiKey = apiKey;
     this._url = url;
+    this._dryRun = dryRun;
     this._sdkType = SdkType.CLIENT;
     this._shouldReconnect = shouldReconnect;
     this._globalMaxRetries = globalMaxRetries;
@@ -197,6 +200,61 @@ export class RunwareBase {
   }
 
   protected isWebsocketReadyState = () => this._ws?.readyState === 1;
+
+  protected isWebsocketHealthyForSend = () =>
+    this.isWebsocketReadyState() && this._missedPongCount === 0;
+
+  protected canSendMessage = (taskType?: string) =>
+    taskType === ETaskType.AUTHENTICATION
+      ? this.isWebsocketHealthyForSend()
+      : this.isWebsocketHealthyForSend() && !!this._connectionSessionUUID;
+
+  protected closeCurrentWebsocket() {
+    if (this._ws) {
+      try {
+        if (typeof this._ws.terminate === "function") {
+          this._ws.terminate();
+        } else {
+          this._ws.close();
+        }
+      } catch {}
+    }
+    this._connectionSessionUUID = undefined;
+    this.stopHeartbeat();
+  }
+
+  private getReadyStateLabel(readyState?: number): string {
+    if (readyState === 0) return "CONNECTING";
+    if (readyState === 1) return "OPEN";
+    if (readyState === 2) return "CLOSING";
+    if (readyState === 3) return "CLOSED";
+    return "UNKNOWN";
+  }
+
+  private createConnectionTimeoutError({
+    retryInterval,
+    maxRetry,
+  }: {
+    retryInterval: number;
+    maxRetry: number;
+  }): Error {
+    const readyState =
+      typeof this._ws?.readyState === "number" ? this._ws.readyState : undefined;
+    const readyStateLabel = this.getReadyStateLabel(readyState);
+    const sessionState = this._connectionSessionUUID ? "present" : "missing";
+    const heartbeatState =
+      this._missedPongCount > 0
+        ? `unhealthy (${this._missedPongCount}/${this._maxMissedPongs} missed pongs)`
+        : `healthy (${this._missedPongCount}/${this._maxMissedPongs} missed pongs)`;
+    const timeoutMs = retryInterval * maxRetry;
+
+    return new Error(
+      `WebSocket reconnection timed out after ${timeoutMs}ms while waiting for an OPEN authenticated connection. ` +
+        `Last state: readyState=${readyStateLabel}${readyState === undefined ? "" : ` (${readyState})`}, ` +
+        `session=${sessionState}, heartbeat=${heartbeatState}. ` +
+        `The SDK did not send the request into the stale socket; check network connectivity, API key validity, and server availability.`,
+    );
+  }
 
   // protected addListener({
   //   lis,
@@ -415,23 +473,15 @@ export class RunwareBase {
 
   // We moving to an array format, it make sense to consolidate all request to an array here
   protected send = async (msg: Object) => {
-    if (!this.isWebsocketReadyState()) {
+    const taskType = (msg as { taskType?: string })?.taskType ?? "unknown";
+    const taskUUID = (msg as { taskUUID?: string })?.taskUUID;
+
+    if (!this.canSendMessage(taskType)) {
       this._logger.sendReconnecting();
-      if (this._ws) {
-        try {
-          if (typeof this._ws.terminate === "function") {
-            this._ws.terminate();
-          } else {
-            this._ws.close();
-          }
-        } catch {}
-      }
-      this._connectionSessionUUID = undefined;
+      this.closeCurrentWebsocket();
       // ensureConnection either resolves (ws ready) or throws
       await this.ensureConnection();
     }
-    const taskType = (msg as any)?.taskType;
-    const taskUUID = (msg as any)?.taskUUID;
     this._logger.messageSent(taskType, taskUUID);
     this._ws.send(JSON.stringify([msg]));
   };
@@ -1835,12 +1885,25 @@ export class RunwareBase {
 
         let retryIntervalId: any;
         let pollingIntervalId: any;
+        let timeoutId: any;
 
         const clearAllIntervals = () => {
           this.ensureConnectionUUID = null;
           clearInterval(retryIntervalId);
           clearInterval(pollingIntervalId);
+          clearTimeout(timeoutId);
         };
+
+        timeoutId = setTimeout(() => {
+          clearAllIntervals();
+          this._logger.ensureConnectionTimeout();
+          reject(
+            this.createConnectionTimeoutError({
+              retryInterval,
+              maxRetry: MAX_RETRY,
+            }),
+          );
+        }, retryInterval * MAX_RETRY);
 
         if (this._sdkType === SdkType.SERVER) {
           retryIntervalId = setInterval(async () => {
@@ -1868,7 +1931,12 @@ export class RunwareBase {
               } else if (retry >= MAX_RETRY) {
                 clearAllIntervals();
                 this._logger.ensureConnectionTimeout();
-                reject(new Error("Retry timed out"));
+                reject(
+                  this.createConnectionTimeoutError({
+                    retryInterval,
+                    maxRetry: MAX_RETRY,
+                  }),
+                );
               } else {
                 if (SHOULD_RETRY) {
                   this._logger.reconnecting(retry + 1);
@@ -2034,6 +2102,6 @@ export class RunwareBase {
   };
 
   private connected = () =>
-    this.isWebsocketReadyState() && !!this._connectionSessionUUID;
+    this.isWebsocketHealthyForSend() && !!this._connectionSessionUUID;
   //end of data
 }

--- a/Runware/Runware-client.ts
+++ b/Runware/Runware-client.ts
@@ -8,7 +8,9 @@ export class RunwareClient extends RunwareBase {
     const { shouldReconnect, ...rest } = props;
 
     super(rest);
-    const url = buildSdkUrl(this._url || "");
+    const url = buildSdkUrl(this._url || "", {
+      dryRun: this._dryRun ? 1 : undefined,
+    });
     this._ws = new (ReconnectingWebsocket as any)(
       url
     ) as ReconnectingWebsocketProps;

--- a/Runware/Runware-server.ts
+++ b/Runware/Runware-server.ts
@@ -29,7 +29,9 @@ export class RunwareServer extends RunwareBase {
     this.resetConnection();
 
     try {
-      const url = buildSdkUrl(this._url);
+      const url = buildSdkUrl(this._url, {
+        dryRun: this._dryRun ? 1 : undefined,
+      });
       this._logger.connecting(url);
 
       this._ws = new WebSocket(url, {
@@ -125,23 +127,15 @@ export class RunwareServer extends RunwareBase {
   }
 
   protected send = async (msg: Object) => {
-    if (!this.isWebsocketReadyState()) {
+    const taskType = (msg as { taskType?: string })?.taskType ?? "unknown";
+    const taskUUID = (msg as { taskUUID?: string })?.taskUUID;
+
+    if (!this.canSendMessage(taskType)) {
       this._logger.sendReconnecting();
-      if (this._ws) {
-        try {
-          if (typeof this._ws.terminate === "function") {
-            this._ws.terminate();
-          } else {
-            this._ws.close();
-          }
-        } catch {}
-      }
-      this._connectionSessionUUID = undefined;
+      this.closeCurrentWebsocket();
       // ensureConnection either resolves (ws ready) or throws
       await this.ensureConnection();
     }
-    const taskType = (msg as any)?.taskType;
-    const taskUUID = (msg as any)?.taskUUID;
     this._logger.messageSent(taskType, taskUUID);
     this._ws.send(JSON.stringify([msg]));
   };

--- a/Runware/reconnect.ts
+++ b/Runware/reconnect.ts
@@ -16,6 +16,7 @@ type Options = {
   connectionTimeout?: number;
   maxRetries?: number;
   debug?: boolean;
+  logger?: (...params: unknown[]) => void;
 };
 
 const isWebSocket = (constructor) => constructor && constructor.CLOSING === 2;
@@ -101,9 +102,7 @@ const ReconnectingWebsocket = function (
     );
   }
 
-  const log = config.debug
-    ? (...params) => console.log("RWS:", ...params)
-    : () => {};
+  const log = config.debug && config.logger ? config.logger : () => {};
 
   /**
    * Not using dispatchEvent, otherwise we must use a DOM Event object

--- a/Runware/types.ts
+++ b/Runware/types.ts
@@ -40,6 +40,7 @@ export type RunwareBaseType = {
   timeoutDuration?: number;
   heartbeatInterval?: number;
   enableLogging?: boolean;
+  dryRun?: boolean;
 };
 
 export type IOutputType = "base64Data" | "dataURI" | "URL";

--- a/Runware/utils.ts
+++ b/Runware/utils.ts
@@ -11,9 +11,22 @@ import pkg from "../package.json";
 
 export const SDK_VERSION = pkg.version;
 
-export function buildSdkUrl(baseUrl: string): string {
+export function buildSdkUrl(
+  baseUrl: string,
+  extraParams?: Record<string, string | number | boolean | undefined>,
+): string {
+  const params = new URLSearchParams();
+  params.set("sdk", "js");
+  params.set("version", SDK_VERSION);
+  if (extraParams) {
+    for (const [key, value] of Object.entries(extraParams)) {
+      if (value !== undefined) {
+        params.set(key, String(value));
+      }
+    }
+  }
   const separator = baseUrl.includes("?") ? "&" : "?";
-  return `${baseUrl}${separator}sdk=js&version=${SDK_VERSION}`;
+  return `${baseUrl}${separator}${params.toString()}`;
 }
 
 export const TIMEOUT_DURATION = 60000; // 120S;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runware/sdk-js",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The SDK is used to run image inference with the Runware API, powered by the RunWare inference platform. It can be used to generate imaged with text-to-image and image-to-image. It also allows the use of an existing gallery of models or selecting any model or LoRA from the CivitAI gallery. The API also supports upscaling, background removal, inpainting and outpainting, and a series of other ControlNet models.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/readme.md
+++ b/readme.md
@@ -739,6 +739,11 @@ export type TImageMaskingResponse = {
 
 ## Changelog
 
+### - v1.3.1
+
+- Add WebSocket health checks: half-open ("zombie") connections are now detected via heartbeat ping/pong and the socket is reconnected before sending, so requests are no longer lost into a dead connection.
+- Add `dryRun` option: when enabled, the SDK connects in dry-run mode (`dryRun=1`) so requests are validated by the server without executing inference.
+
 ### - v1.3.0
 
 - Add `training` task type.

--- a/tests/Runware/connection/half-open-get-response.test.ts
+++ b/tests/Runware/connection/half-open-get-response.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { RunwareBase } from "../../../Runware/Runware-base";
+import { RunwareServer } from "../../../Runware/Runware-server";
+import { ETaskType } from "../../../Runware/types";
+
+const TASK_UUID = "ceab18cd-6b43-427d-bc65-0f382007265e";
+
+class FakeSocket {
+  readyState = 1;
+  sent: string[] = [];
+  closeCalls = 0;
+  terminateCalls = 0;
+
+  send(payload: string) {
+    this.sent.push(payload);
+  }
+
+  close() {
+    this.closeCalls++;
+    this.readyState = 3;
+  }
+
+  terminate() {
+    this.terminateCalls++;
+    this.readyState = 3;
+  }
+}
+
+type Harness = {
+  _ws: FakeSocket;
+  _connectionSessionUUID?: string;
+  _missedPongCount: number;
+  _maxMissedPongs: number;
+  connected: () => boolean;
+  send: (msg: Record<string, unknown>) => Promise<void>;
+  ensureConnection: () => Promise<unknown>;
+};
+
+class TestRunwareServer extends RunwareServer {
+  protected async connect() {}
+}
+
+function createBaseHarness() {
+  return new RunwareBase({
+    apiKey: "test-key",
+    url: "ws://local-half-open-test",
+    shouldReconnect: false,
+  }) as unknown as Harness;
+}
+
+function createServerHarness() {
+  return new TestRunwareServer({
+    apiKey: "test-key",
+    url: "ws://local-half-open-test",
+    shouldReconnect: false,
+  }) as unknown as Harness;
+}
+
+function putInHalfOpenState(harness: Harness) {
+  const staleSocket = new FakeSocket();
+  harness._ws = staleSocket;
+  harness._connectionSessionUUID = "session-open-but-heartbeat-stale";
+  harness._missedPongCount = 1;
+  return staleSocket;
+}
+
+function sentGetResponse(socket: FakeSocket) {
+  return socket.sent.some((payload) => {
+    const message = JSON.parse(payload)[0] as Record<string, unknown>;
+    return (
+      message.taskType === ETaskType.GET_RESPONSE &&
+      message.taskUUID === TASK_UUID
+    );
+  });
+}
+
+describe("half-open getResponse send guard", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("connected() is false after a missed pong even when the socket is OPEN", () => {
+    const sdk = createBaseHarness();
+    const staleSocket = putInHalfOpenState(sdk);
+
+    expect(staleSocket.readyState).toBe(1);
+    expect(sdk.connected()).toBe(false);
+  });
+
+  test.each([
+    ["base client path", createBaseHarness],
+    ["server override path", createServerHarness],
+  ])(
+    "%s reconnects before sending getResponse on a heartbeat-stale OPEN socket",
+    async (_label, createHarness) => {
+      const sdk = createHarness();
+      const staleSocket = putInHalfOpenState(sdk);
+      const freshSocket = new FakeSocket();
+      const ensureConnection = vi.fn(async () => {
+        sdk._ws = freshSocket;
+        sdk._connectionSessionUUID = "fresh-session";
+        sdk._missedPongCount = 0;
+        return true;
+      });
+      sdk.ensureConnection = ensureConnection;
+
+      await sdk.send({
+        taskType: ETaskType.GET_RESPONSE,
+        taskUUID: TASK_UUID,
+      });
+
+      expect(ensureConnection).toHaveBeenCalledTimes(1);
+      expect(staleSocket.terminateCalls + staleSocket.closeCalls).toBe(1);
+      expect(sentGetResponse(staleSocket)).toBe(false);
+      expect(sentGetResponse(freshSocket)).toBe(true);
+      expect(freshSocket.sent).toHaveLength(1);
+    },
+  );
+
+  test.each([
+    ["base client path", createBaseHarness],
+    ["server override path", createServerHarness],
+  ])(
+    "%s rejects before sending when reconnection cannot recover",
+    async (_label, createHarness) => {
+      const sdk = createHarness();
+      const staleSocket = putInHalfOpenState(sdk);
+      sdk.ensureConnection = vi.fn(async () => {
+        throw new Error("Retry timed out");
+      });
+
+      await expect(
+        sdk.send({
+          taskType: ETaskType.GET_RESPONSE,
+          taskUUID: TASK_UUID,
+        }),
+      ).rejects.toThrow("Retry timed out");
+
+      expect(sentGetResponse(staleSocket)).toBe(false);
+    },
+  );
+
+  test("authentication can still send on an OPEN socket before session UUID exists", async () => {
+    const sdk = createBaseHarness();
+    const socket = new FakeSocket();
+    const ensureConnection = vi.fn();
+    sdk._ws = socket;
+    sdk._connectionSessionUUID = undefined;
+    sdk._missedPongCount = 0;
+    sdk.ensureConnection = ensureConnection;
+
+    await sdk.send({
+      taskType: ETaskType.AUTHENTICATION,
+      apiKey: "test-key",
+    });
+
+    expect(ensureConnection).not.toHaveBeenCalled();
+    expect(socket.sent).toHaveLength(1);
+  });
+
+  test("heartbeat termination threshold remains three missed pongs", () => {
+    const sdk = createBaseHarness();
+
+    sdk._missedPongCount = 1;
+    expect(sdk._missedPongCount >= sdk._maxMissedPongs).toBe(false);
+
+    sdk._missedPongCount = 2;
+    expect(sdk._missedPongCount >= sdk._maxMissedPongs).toBe(false);
+
+    sdk._missedPongCount = 3;
+    expect(sdk._missedPongCount >= sdk._maxMissedPongs).toBe(true);
+  });
+
+  test("client ensureConnection rejects after a finite timeout with connection state", async () => {
+    vi.useFakeTimers();
+    const sdk = createBaseHarness();
+    const closedSocket = new FakeSocket();
+    closedSocket.readyState = 3;
+    sdk._ws = closedSocket;
+    sdk._connectionSessionUUID = undefined;
+    sdk._missedPongCount = 0;
+
+    const promise = sdk.ensureConnection();
+    const assertion = expect(promise).rejects.toThrow(
+      "WebSocket reconnection timed out after 60000ms",
+    );
+
+    await vi.advanceTimersByTimeAsync(60_001);
+
+    await assertion;
+  });
+
+  test("client ensureConnection timeout explains heartbeat-stale state", async () => {
+    vi.useFakeTimers();
+    const sdk = createBaseHarness();
+    const staleSocket = putInHalfOpenState(sdk);
+
+    const promise = sdk.ensureConnection();
+    const assertion = expect(promise).rejects.toThrow(
+      /readyState=OPEN \(1\), session=present, heartbeat=unhealthy \(1\/3 missed pongs\).*did not send the request/,
+    );
+
+    await vi.advanceTimersByTimeAsync(60_001);
+
+    await assertion;
+    expect(sentGetResponse(staleSocket)).toBe(false);
+  });
+});

--- a/tests/reproduce-half-open-get-response.ts
+++ b/tests/reproduce-half-open-get-response.ts
@@ -1,0 +1,159 @@
+import { RunwareBase } from "../Runware/Runware-base";
+import { ETaskType } from "../Runware/types";
+
+const TASK_UUID = "ceab18cd-6b43-427d-bc65-0f382007265e";
+const expectFixed = process.argv.includes("--expect-fixed");
+
+type SentMessage = {
+  taskType?: string;
+  taskUUID?: string;
+};
+
+class FakeSocket {
+  readyState = 1;
+  sent: string[] = [];
+  closeCalls = 0;
+  terminateCalls = 0;
+
+  constructor(
+    readonly label: string,
+    private readonly afterSend?: (payload: string) => void,
+  ) {}
+
+  send(payload: string) {
+    this.sent.push(payload);
+    this.afterSend?.(payload);
+  }
+
+  close() {
+    this.closeCalls++;
+    this.readyState = 3;
+  }
+
+  terminate() {
+    this.terminateCalls++;
+    this.readyState = 3;
+  }
+}
+
+type RunwareHarness = {
+  _ws: FakeSocket;
+  _connectionSessionUUID?: string;
+  _missedPongCount: number;
+  _globalMessages: Record<string, unknown>;
+  connected: () => boolean;
+  ensureConnection: () => Promise<unknown>;
+  getResponse: <T>(payload: { taskUUID: string }) => Promise<T[]>;
+};
+
+function parseSentMessage(payload: string): SentMessage {
+  const parsed = JSON.parse(payload) as SentMessage[];
+  return parsed[0] ?? {};
+}
+
+function hasGetResponse(socket: FakeSocket) {
+  return socket.sent.some((payload) => {
+    const message = parseSentMessage(payload);
+    return (
+      message.taskType === ETaskType.GET_RESPONSE &&
+      message.taskUUID === TASK_UUID
+    );
+  });
+}
+
+async function main() {
+  const sdk = new RunwareBase({
+    apiKey: "test-key",
+    url: "ws://local-half-open-repro",
+    shouldReconnect: false,
+    globalMaxRetries: 1,
+    timeoutDuration: 1000,
+    heartbeatInterval: 15000,
+  }) as unknown as RunwareHarness;
+
+  const staleSocket = new FakeSocket("stale");
+  const freshSocket = new FakeSocket("fresh", (payload) => {
+    const message = parseSentMessage(payload);
+    setTimeout(() => {
+      if (message.taskUUID) {
+        sdk._globalMessages[message.taskUUID] = [
+          {
+            taskType: message.taskType,
+            taskUUID: message.taskUUID,
+            status: "success",
+            source: "fresh-socket",
+          },
+        ];
+      }
+    }, 0);
+  });
+
+  let reconnects = 0;
+
+  sdk._ws = staleSocket;
+  sdk._connectionSessionUUID = "session-open-but-heartbeat-stale";
+  sdk._missedPongCount = 1;
+  sdk.ensureConnection = async () => {
+    reconnects++;
+    sdk._ws = freshSocket;
+    sdk._connectionSessionUUID = "fresh-session";
+    sdk._missedPongCount = 0;
+    return true;
+  };
+
+  console.log("connectedBefore", sdk.connected());
+  console.log("missedPongCountBefore", sdk._missedPongCount);
+
+  let results: unknown[] | undefined;
+  let error: unknown;
+  try {
+    results = await sdk.getResponse({ taskUUID: TASK_UUID });
+  } catch (err) {
+    error = err;
+  }
+
+  console.log("reconnects", reconnects);
+  console.log("staleSentCount", staleSocket.sent.length);
+  console.log("staleSentGetResponse", hasGetResponse(staleSocket));
+  console.log("freshSentCount", freshSocket.sent.length);
+  console.log("freshSentGetResponse", hasGetResponse(freshSocket));
+
+  if (error) {
+    console.log("error", String(error));
+  } else {
+    console.log("result", JSON.stringify(results));
+  }
+
+  if (hasGetResponse(staleSocket) && error) {
+    console.log("classification", "half-open poll loss reproduced");
+  } else if (!error && reconnects > 0 && hasGetResponse(freshSocket)) {
+    console.log("classification", "fixed behavior observed");
+  } else {
+    console.log("classification", "unexpected behavior");
+  }
+
+  if (!expectFixed) return;
+
+  const failures: string[] = [];
+  if (error) {
+    failures.push(`getResponse failed: ${String(error)}`);
+  }
+  if (hasGetResponse(staleSocket)) {
+    failures.push("stale socket received getResponse");
+  }
+  if (reconnects !== 1) {
+    failures.push(`expected one reconnect, got ${reconnects}`);
+  }
+  if (!hasGetResponse(freshSocket)) {
+    failures.push("fresh socket did not receive getResponse");
+  }
+
+  if (failures.length) {
+    throw new Error(failures.join("; "));
+  }
+}
+
+main().catch((err) => {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request introduces important improvements to the WebSocket connection handling in the SDK, primarily to prevent requests from being lost due to "half-open" (zombie) WebSocket connections. It also adds a new `dryRun` mode for request validation without execution. The changes enhance connection health checks, error reporting, and configurability, and are covered by new and updated tests.

Key changes include:

**WebSocket Health Checks and Robustness:**

* Added heartbeat-based health checks to detect and recover from half-open WebSocket connections. Now, before sending a message, the SDK verifies both the socket's ready state and heartbeat status; if unhealthy, it reconnects before sending, ensuring requests are not lost into stale sockets. [[1]](diffhunk://#diff-e2d4c3399375ba7454cc75ff7d65f355884d3fd0034249ff8a35b9909c24cae7R204-R258) [[2]](diffhunk://#diff-e2d4c3399375ba7454cc75ff7d65f355884d3fd0034249ff8a35b9909c24cae7L418-L434) [[3]](diffhunk://#diff-e2d4c3399375ba7454cc75ff7d65f355884d3fd0034249ff8a35b9909c24cae7L2037-R2105) [[4]](diffhunk://#diff-1d3e2b68671a7e599e457b62f2e3a3205885a771500684ac18d50e499a515508L128-L144) [[5]](diffhunk://#diff-2893e1abe09a275b4fc0421ff881dd65e27d20cbd84f79f90de47f1fc025c514R1-R208) [[6]](diffhunk://#diff-c48b31da698c1cfc15bd9738a1eb7ba946d8c4e681b09cb68f1090cd96adc5d7R1-R159)
* Improved connection timeout and error reporting: timeouts now provide detailed information about the last connection state, including ready state, session, and heartbeat status, making debugging easier. [[1]](diffhunk://#diff-e2d4c3399375ba7454cc75ff7d65f355884d3fd0034249ff8a35b9909c24cae7R1888-R1907) [[2]](diffhunk://#diff-e2d4c3399375ba7454cc75ff7d65f355884d3fd0034249ff8a35b9909c24cae7L1871-R1939)

**New Features:**

* Introduced a `dryRun` option (in `RunwareBaseType` and constructors) that, when enabled, appends `dryRun=1` to the SDK URL, allowing requests to be validated by the server without executing inference. [[1]](diffhunk://#diff-e2d4c3399375ba7454cc75ff7d65f355884d3fd0034249ff8a35b9909c24cae7R98) [[2]](diffhunk://#diff-e2d4c3399375ba7454cc75ff7d65f355884d3fd0034249ff8a35b9909c24cae7R110-R114) [[3]](diffhunk://#diff-68307610efa3c1ece8688d44e91c57c777d70dcca372875caff4fe0df03b90b7R43) [[4]](diffhunk://#diff-d90c330c4837734f8cca6a3da4a6eb53d2ae4c58357d485348c454d5226e7f87L14-R29) [[5]](diffhunk://#diff-b6bd7a2ea10d53e1454088b836ac14a9e6c0ea82272d178a33a207a332ed474cL11-R13) [[6]](diffhunk://#diff-1d3e2b68671a7e599e457b62f2e3a3205885a771500684ac18d50e499a515508L32-R34)

**Configurability and Logging:**

* The reconnect logic in `Runware/reconnect.ts` now supports a custom logger function, making debug logging more flexible and testable. [[1]](diffhunk://#diff-2808c322b41d2bb53cfb312cf79ef3f24fe9a544ed6ed8df7fdd0943c4922744R19) [[2]](diffhunk://#diff-2808c322b41d2bb53cfb312cf79ef3f24fe9a544ed6ed8df7fdd0943c4922744L104-R105)

**Testing and Documentation:**

* Added comprehensive tests to verify correct handling of half-open connections and reconnection logic, ensuring that requests are not sent to stale sockets and that timeouts behave as expected. [[1]](diffhunk://#diff-2893e1abe09a275b4fc0421ff881dd65e27d20cbd84f79f90de47f1fc025c514R1-R208) [[2]](diffhunk://#diff-c48b31da698c1cfc15bd9738a1eb7ba946d8c4e681b09cb68f1090cd96adc5d7R1-R159)
* Updated the `readme.md` changelog to document the new version (`1.3.1`) and summarize these improvements.
* Updated `package.json` version to `1.3.1`.